### PR TITLE
fix: convert spec type for NN

### DIFF
--- a/src/mouse/nn_detection/neural_network.py
+++ b/src/mouse/nn_detection/neural_network.py
@@ -331,7 +331,7 @@ class USVDetector(pl.LightningModule):
         List[SqueakBox]
             List of predicted boxes.
         """
-        spec = spec_data.spec
+        spec = spec_data.spec.float()
         times = spec_data.times
         freqs = spec_data.freqs
 


### PR DESCRIPTION
Expected result: NN predictor can work with denoised spectrogram